### PR TITLE
Ignore cref and autoref for nbsp inspection

### DIFF
--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
@@ -30,7 +30,7 @@ open class LatexNonBreakingSpaceInspection : TexifyInspectionBase() {
         /**
          * All commands that should not have a forced breaking space.
          */
-        val IGNORED_COMMANDS = setOf("\\citet", "\\citet*", "\\Citet", "\\Citet*")
+        val IGNORED_COMMANDS = setOf("\\citet", "\\citet*", "\\Citet", "\\Citet*", "\\cref", "\\cpageref", "\\autoref")
     }
 
     override fun getInspectionGroup() = InsightGroup.LATEX


### PR DESCRIPTION
Hey,
great project, thank you so much! 
I've been bothered by a few false alarms and this is my attempt to fix a few of them :-).

The commands \cref, \cpageref and \autoref automatically produce the name of the section/figure/etc..
Therefore there is no need for a non-breaking space before them.

I have no idea about the codebase, so better double check the change. 